### PR TITLE
Fetch third-party libraries from one CDN

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -110,20 +110,20 @@
     </style>
     <title>Election 2020 Results</title>
 
-    <script src="https://unpkg.com/dayjs@1.9.5/dayjs.min.js"
-            integrity="sha384-I8UysxWXKTbAFvVRecMrWcGRGR4RDZ7mOuoWjMA84MWM0OQ+4IriYjgc2+hHzEo8"
+    <script src="https://cdn.jsdelivr.net/npm/dayjs@1.9.5/dayjs.min.js"
+            integrity="sha256-mD+FyduhfcEZ4oQ997JNfyad4Zd/L5GmOpdT1tYEHDY="
             crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/dayjs@1.9.5/plugin/utc.js"
-            integrity="sha384-PcsSBVvWDlTmn0uPlrBbd/cUxDra/qov78qWgB2Qh6TwCiXAyuJQerEmS4PoVaRQ"
+    <script src="https://cdn.jsdelivr.net/npm/dayjs@1.9.5/plugin/utc.js"
+            integrity="sha256-J2nxnU0y9JlG15m3wDlZvbnX9srbkEe7U4w/PaK0MQ4="
             crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/dayjs@1.9.5/plugin/relativeTime.js"
-            integrity="sha384-Dy9nN0yYkuj/yhJJITfTyN7H84joqwvGkDsyXr+JavETPnhOzTe48kfPQEI1ee0Q"
+    <script src="https://cdn.jsdelivr.net/npm/dayjs@1.9.5/plugin/relativeTime.js"
+            integrity="sha256-tMJ/JI74gvcd/JCL4zekEwHfyHfT2XKUd5GAZn6fJOU="
             crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/dayjs@1.9.5/plugin/advancedFormat.js"
-            integrity="sha384-y6wn9TDoovj2ZC4/cCf+qm4Kxiha/hhqfOb/L5RThIKLYDrhcLLfTSPyyHLMM9kF"
+    <script src="https://cdn.jsdelivr.net/npm/dayjs@1.9.5/plugin/advancedFormat.js"
+            integrity="sha256-4b578grXxtBW3ACbmeHTe1Kwnbc0e/cBGNYkgJPXujg="
             crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/dayjs@1.9.5/plugin/timezone.js"
-            integrity="sha384-ABtdoJNGKT1efF9sGomlK3/sBQIhkJb0H32JGT5/7DP8H5kKBMS5mwMLu0SExhQH"
+    <script src="https://cdn.jsdelivr.net/npm/dayjs@1.9.5/plugin/timezone.js"
+            integrity="sha256-XPby8jENTi0g1ZfQE8s0yIUc6LdTi7OkipyXhHCytNQ="
             crossorigin="anonymous"></script>
 
     <script type="text/javascript">
@@ -205,8 +205,8 @@
         </div>
     </div>
 </div>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-        integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"
+        integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="
         crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"


### PR DESCRIPTION
###### Motivation

For performance it's better to fetch third-party libraries from one CDN instead of several different CDNs. This avoids multiple DNS lookups and connections.

###### Changes

Fetch third-party libraries from [jsDelivr](https://www.jsdelivr.com/).

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [ ] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
